### PR TITLE
update target to ensure compilation does not alter generated code

### DIFF
--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
-    "target": "es6"
+    "target": "esnext"
   },
   "exclude": [
     "node_modules"

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -8,12 +8,12 @@
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
+    "noUnusedLocals": true,
     "pretty": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es6",
     "strictNullChecks": true,
-    "noUnusedLocals": true
+    "target": "es6"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
This PR updates the TypeScript compilation target to the latest possible ECMAScript standard to ensure that the JavaScript output is not altered by the compiler. This will ensure that the generated JavaScript code is the same as the TypeScript code minus types.

The reasoning behind this has been discussed previously, but the short version is to avoid being unable to test certain features because they have been transpiled to something else.